### PR TITLE
Restrict calendar event retrieval to dates between today and two year…

### DIFF
--- a/main.py
+++ b/main.py
@@ -125,7 +125,8 @@ def get_change(service, calendar_ids):
                         service.events()
                         .list(
                             calendarId=calendar_id,
-                            timeMin="1970-01-01T00:00:00Z",
+                            timeMin=datetime.datetime.now().isoformat() + "Z",  # P45bf
+                            timeMax=(datetime.datetime.now() + datetime.timedelta(days=730)).isoformat() + "Z",  # Pdb62
                             singleEvents=True,
                             orderBy="startTime",
                             pageToken=page_token,


### PR DESCRIPTION
…s from now

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ka-zuu/GoogleCalendar_to_Discord_Python?shareId=XXXX-XXXX-XXXX-XXXX).